### PR TITLE
making the examples preformatted

### DIFF
--- a/lib/Hadoop/Streaming.pm
+++ b/lib/Hadoop/Streaming.pm
@@ -89,11 +89,13 @@ Reduce jobs are provided a stream of key\tvalue lines.  multivalued keys appear 
 Hadoop::Mapper consumes and chomps lines from STDIN and calls map($line) once per line.  This is initiated by the run() method.
 
 example mapper input:
+
     line1
     line2
     line3
 
 Hadoop::Mapper transforms this into 3 calls to map()
+
     map(line1)
     map(line2)
     map(line3)
@@ -103,6 +105,7 @@ Hadoop::Mapper transforms this into 3 calls to map()
 Hadoop::Reducer abstracts this stream into an interface of (key, value-iterator).  reduce() is called once per key, instead of once per line.  The reduce job pulls values from the iterator and outputs key/value pairs to STDOUT.  emit() is provided as a convenience for outputing key/value pairs.
 
 example reducer input:
+
     key1 value1
     key2 valuea
     key2 valuec
@@ -111,6 +114,7 @@ example reducer input:
     key3 valuebar
 
 Hadoop::Streaming::Reduce transforms this input into three calls to reduce():
+
     reduce( key,  iterator_over(qw(value1)) );
     reduce( key2, iterator_over(qw(valuea valuec valueb)) );
     reduce( key3, iterator_over(qw(valuefoo valuebarr)) );
@@ -118,6 +122,7 @@ Hadoop::Streaming::Reduce transforms this input into three calls to reduce():
 =item Hadoop::Streaming::Combiner interface
 
 The Hadoop::Streaming::Combiner interface is analagous to the Hadoop::Streaming::Reducer interface.  combine() is called instead of reduce() for each key.  The above example would produce three calls to combine():
+
     combine( key,  iterator_over(qw(value1)) );
     combine( key2, iterator_over(qw(valuea valuec valueb)) );
     combine( key3, iterator_over(qw(valuefoo valuebarr)) );


### PR DESCRIPTION
add CRs in the doc so that the examples are seen by POD as preformatted.
