### PR TITLE
convert from Moose to Moo

### DIFF
--- a/examples/analog/map.pl
+++ b/examples/analog/map.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package Analog::Mapper;
-use Moose;
+use Moo;
 with 'Hadoop::Streaming::Mapper';
 
 sub map {

--- a/examples/analog/reduce.pl
+++ b/examples/analog/reduce.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package Analog::Reducer;
-use Moose;
+use Moo;
 with 'Hadoop::Streaming::Reducer';
 
 sub reduce {

--- a/examples/wordcount/map.pl
+++ b/examples/wordcount/map.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package Wordcount::Mapper;
-use Moose;
+use Moo;
 with 'Hadoop::Streaming::Mapper';
 
 sub map {

--- a/examples/wordcount/reduce.pl
+++ b/examples/wordcount/reduce.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package WordCount::Reducer;
-use Moose;
+use Moo;
 with qw/Hadoop::Streaming::Reducer/;
 
 sub reduce {

--- a/lib/Hadoop/Streaming.pm
+++ b/lib/Hadoop/Streaming.pm
@@ -7,7 +7,7 @@ package Hadoop::Streaming;
 My/Hadoop/Example.pm:
 
     package My::Hadoop::Example;
-    use Any::Moose qw(Role);
+    use Moo::Role;
 
     sub map
     {
@@ -34,15 +34,15 @@ My/Hadoop/Example.pm:
     }
 
     package My::Hadoop::Example::Mapper;
-    use Any::Moose;
+    use Moo;
     with qw(Hadoop::Streaming::Mapper My::Hadoop::Example);
 
     package My::Hadoop::Example::Combiner;
-    use Any::Moose;
+    use Moo;
     with qw(Hadoop::Streaming::Combiner My::Hadoop::Example);
 
     package My::Hadoop::Example::Reducer;
-    use Any::Moose;
+    use Moo;
     with qw(Hadoop::Streaming::Reducer  My::Hadoop::Example);
 
     1;

--- a/lib/Hadoop/Streaming/Combiner.pm
+++ b/lib/Hadoop/Streaming/Combiner.pm
@@ -1,5 +1,5 @@
 package Hadoop::Streaming::Combiner;
-use Any::Moose  qw(Role);
+use Moo::Role;
 
 use IO::Handle;
 use Hadoop::Streaming::Reducer::Input;
@@ -14,7 +14,7 @@ requires qw/combine/;
     #!/usr/bin/env perl
 
     package WordCount::Combiner;
-    use Any::Moose;
+    use Moo;
     with qw/Hadoop::Streaming::Combiner/;
 
     sub combine {

--- a/lib/Hadoop/Streaming/Mapper.pm
+++ b/lib/Hadoop/Streaming/Mapper.pm
@@ -1,5 +1,5 @@
 package Hadoop::Streaming::Mapper;
-use Any::Moose qw(Role);
+use Moo::Role;
 use IO::Handle;
 
 with 'Hadoop::Streaming::Role::Emitter';
@@ -13,7 +13,7 @@ requires qw(map);  # from consumer
   #!/usr/bin/env perl
   
   package Wordcount::Mapper;
-  use Any::Moose;
+  use Moo;
   with 'Hadoop::Streaming::Mapper';
   
   sub map

--- a/lib/Hadoop/Streaming/Reducer.pm
+++ b/lib/Hadoop/Streaming/Reducer.pm
@@ -1,5 +1,5 @@
 package Hadoop::Streaming::Reducer;
-use Any::Moose qw(Role);
+use Moo::Role;
 
 use IO::Handle;
 use Hadoop::Streaming::Reducer::Input;
@@ -14,7 +14,7 @@ requires qw/reduce/;
     #!/usr/bin/env perl
 
     package WordCount::Reducer;
-    use Any::Moose;
+    use Moo;
     with qw/Hadoop::Streaming::Reducer/;
 
     sub reduce {

--- a/lib/Hadoop/Streaming/Reducer/Input.pm
+++ b/lib/Hadoop/Streaming/Reducer/Input.pm
@@ -1,5 +1,5 @@
 package Hadoop::Streaming::Reducer::Input;
-use Any::Moose;
+use Moo;
 use Hadoop::Streaming::Reducer::Input::Iterator;
 
 #ABSTRACT: Parse input stream for reducer

--- a/lib/Hadoop/Streaming/Reducer/Input/Iterator.pm
+++ b/lib/Hadoop/Streaming/Reducer/Input/Iterator.pm
@@ -1,5 +1,6 @@
 package Hadoop::Streaming::Reducer::Input::Iterator;
-use Any::Moose;
+use Moo;
+use Safe::Isa;
 with 'Hadoop::Streaming::Role::Iterator';
 
 use Hadoop::Streaming::Reducer::Input::ValuesIterator;
@@ -8,7 +9,10 @@ use Hadoop::Streaming::Reducer::Input::ValuesIterator;
 
 has input => (
     is       => 'ro',
-    isa      => 'Hadoop::Streaming::Reducer::Input',
+    isa      => sub {
+        die 'not a Hadoop::Streaming::Reducer::Input object'
+            unless $_[0]->$_isa('Hadoop::Streaming::Reducer::Input');
+    },
     required => 1,
 );
 

--- a/lib/Hadoop/Streaming/Reducer/Input/ValuesIterator.pm
+++ b/lib/Hadoop/Streaming/Reducer/Input/ValuesIterator.pm
@@ -1,5 +1,5 @@
 package Hadoop::Streaming::Reducer::Input::ValuesIterator;
-use Any::Moose;
+use Moo;
 with 'Hadoop::Streaming::Role::Iterator';
 
 #ABSTRACT: Role providing access to values for a given key.

--- a/lib/Hadoop/Streaming/Role/Emitter.pm
+++ b/lib/Hadoop/Streaming/Role/Emitter.pm
@@ -1,5 +1,5 @@
 package Hadoop::Streaming::Role::Emitter;
-use Any::Moose qw(Role);
+use Moo::Role;
 use Params::Validate qw/validate_pos/;
 
 #provides qw(run emit counter status);

--- a/lib/Hadoop/Streaming/Role/Iterator.pm
+++ b/lib/Hadoop/Streaming/Role/Iterator.pm
@@ -1,5 +1,5 @@
 package Hadoop::Streaming::Role::Iterator;
-use Any::Moose qw(Role);
+use Moo::Role;
 
 requires qw(has_next next);
 #ABSTRACT: Role to require has_next and next

--- a/t/analog-mouse/map.pl
+++ b/t/analog-mouse/map.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package Analog::Mapper;
-use Any::Moose;
+use Moo;
 with 'Hadoop::Streaming::Mapper';
 
 sub map {

--- a/t/analog-mouse/reduce.pl
+++ b/t/analog-mouse/reduce.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package Analog::Reducer;
-use Any::Moose;
+use Moo;
 with 'Hadoop::Streaming::Reducer';
 
 sub reduce {

--- a/t/analog/map.pl
+++ b/t/analog/map.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package Analog::Mapper;
-use Moose;
+use Moo;
 with 'Hadoop::Streaming::Mapper';
 
 sub map {

--- a/t/analog/reduce.pl
+++ b/t/analog/reduce.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package Analog::Reducer;
-use Moose;
+use Moo;
 with 'Hadoop::Streaming::Reducer';
 
 sub reduce {

--- a/t/tab-delimited-reduce-input/map.pl
+++ b/t/tab-delimited-reduce-input/map.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package MyMapper;
-use Any::Moose;
+use Moo;
 with 'Hadoop::Streaming::Mapper';
 
 sub map {

--- a/t/tab-delimited-reduce-input/reduce.pl
+++ b/t/tab-delimited-reduce-input/reduce.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package MyReducer;
-use Any::Moose;
+use Moo;
 with 'Hadoop::Streaming::Reducer';
 
 sub reduce {

--- a/t/wordcount/combine.pl
+++ b/t/wordcount/combine.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package WordCount::Combiner;
-use Moose;
+use Moo;
 with qw/Hadoop::Streaming::Combiner/;
 
 sub combine {

--- a/t/wordcount/map.pl
+++ b/t/wordcount/map.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package Wordcount::Mapper;
-use Moose;
+use Moo;
 with 'Hadoop::Streaming::Mapper';
 
 sub map

--- a/t/wordcount/reduce.pl
+++ b/t/wordcount/reduce.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 package WordCount::Reducer;
-use Moose;
+use Moo;
 with qw/Hadoop::Streaming::Reducer/;
 
 sub reduce {


### PR DESCRIPTION
This commit changes from Moose/Any::Moose to Moo.  This makes the module have less dependencies (i.e. the boatload of Moose dependencies).
